### PR TITLE
Add CI workflow for linting, type-checking, and testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  check:
+    name: Lint & type-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+      - uses: extractions/setup-just@v2
+      - run: uv sync --all-extras
+      - run: just check
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+      - uses: extractions/setup-just@v2
+      - run: uv sync --all-extras
+      - run: just test


### PR DESCRIPTION
## Summary
This PR introduces a GitHub Actions CI workflow to automatically run code quality checks and tests on all branches and pull requests.

## Key Changes
- Added `.github/workflows/ci.yml` with two jobs:
  - **Lint & type-check job**: Runs linting and type-checking via the `just check` command
  - **Tests job**: Runs the test suite via the `just test` command
- Both jobs use Python 3.13 with `uv` for dependency management
- Workflow triggers on all branch pushes and pull requests

## Implementation Details
- Uses `astral-sh/setup-uv@v5` for Python environment setup with uv package manager
- Uses `extractions/setup-just@v2` to enable `just` command runner
- Installs all dependencies with `uv sync --all-extras` before running checks
- Runs on `ubuntu-latest` for consistency and cost-effectiveness

https://claude.ai/code/session_018DSqFdJoxAXhwyG7zCkLjX