### PR TITLE
feat: unread message indicators for channels and DMs

### DIFF
--- a/src/meshcore_tools/app.py
+++ b/src/meshcore_tools/app.py
@@ -240,6 +240,21 @@ class MeshCoreApp(App):
             except Exception as exc:
                 _log.warning("Failed to persist channels: %s", exc)
 
+    def _update_tab_labels(self) -> None:
+        """Update F2/F3 tab labels to reflect current unread counts."""
+        if not COMPANION_AVAILABLE:
+            return
+        try:
+            tabbed = self.query_one(TabbedContent)
+            chat_unread = self.query_one(ChatTab).unread_count()
+            chat_tab = tabbed.get_tab("tab_chat")
+            chat_tab.label = "F2 Channels ●" if chat_unread else "F2 Channels"
+            rep_unread = self.query_one(RepeatersTab).unread_count()
+            rep_tab = tabbed.get_tab("tab_repeaters")
+            rep_tab.label = "F3 Contacts ●" if rep_unread else "F3 Contacts"
+        except Exception:
+            pass
+
     def on_channel_message(self, message: "ChannelMessage") -> None:
         if not COMPANION_AVAILABLE:
             return
@@ -253,6 +268,7 @@ class MeshCoreApp(App):
             )
         except Exception:
             pass
+        self._update_tab_labels()
 
     def on_contact_message(self, message: "ContactMessage") -> None:
         if not COMPANION_AVAILABLE:
@@ -266,6 +282,7 @@ class MeshCoreApp(App):
             )
         except Exception:
             pass
+        self._update_tab_labels()
 
     def on_contact_login_changed(self, message: "ContactLoginChanged") -> None:
         if not COMPANION_AVAILABLE:

--- a/src/meshcore_tools/chat.py
+++ b/src/meshcore_tools/chat.py
@@ -61,6 +61,10 @@ class ChatTab(TabPane):
         padding: 0 1;
         color: $text-muted;
     }
+    ChatTab #channel_list ListItem.has-unread Label {
+        text-style: bold;
+        color: $warning;
+    }
     """
 
     def __init__(self) -> None:
@@ -68,6 +72,7 @@ class ChatTab(TabPane):
         self._channels: list[dict] = []
         self._active_channel_idx: int = 0
         self._messages: dict[int, list[dict]] = {}
+        self._unread: dict[int, int] = {}  # channel_idx → unread count
 
     def compose(self) -> ComposeResult:
         yield ListView(id="channel_list")
@@ -138,9 +143,37 @@ class ChatTab(TabPane):
         self.query_one("#msg_content", Static).update("\n".join(lines))
         self.query_one("#msg_log", VerticalScroll).scroll_end(animate=False)
 
+    def _channel_label(self, ch: dict) -> str:
+        """Return the display label for a channel, including unread count if any."""
+        count = self._unread.get(ch["idx"], 0)
+        if count:
+            return f"{ch['name']}  [{count}]"
+        return ch["name"]
+
+    def _refresh_channel_item(self, channel_idx: int) -> None:
+        """Update a single channel list item's label and CSS class."""
+        idxs = [ch["idx"] for ch in self._channels]
+        if channel_idx not in idxs:
+            return
+        pos = idxs.index(channel_idx)
+        ch = self._channels[pos]
+        list_view = self.query_one("#channel_list", ListView)
+        items = list(list_view.query(ListItem))
+        if pos < len(items):
+            items[pos].query_one(Label).update(self._channel_label(ch))
+            if self._unread.get(channel_idx, 0) > 0:
+                items[pos].add_class("has-unread")
+            else:
+                items[pos].remove_class("has-unread")
+
+    def unread_count(self) -> int:
+        """Total unread messages across all channels."""
+        return sum(self._unread.values())
+
     def populate_channels(self, channels: list[dict]) -> None:
         """Called by MeshCoreApp after channels are fetched from the device."""
         self._channels = channels
+        self._unread.clear()
         list_view = self.query_one("#channel_list", ListView)
         list_view.clear()
         for ch in self._channels:
@@ -155,15 +188,27 @@ class ChatTab(TabPane):
             return
         idx = event.list_view.index
         if idx is not None and idx < len(self._channels):
-            self._active_channel_idx = self._channels[idx]["idx"]
+            channel_idx = self._channels[idx]["idx"]
+            had_unread = channel_idx in self._unread
+            self._unread.pop(channel_idx, None)
+            if had_unread:
+                self._refresh_channel_item(channel_idx)
+                getattr(self.app, "_update_tab_labels", lambda: None)()
+            self._active_channel_idx = channel_idx
             self._refresh_log()
 
     def _select_channel(self, channel_idx: int) -> None:
+        had_unread = channel_idx in self._unread
+        self._unread.pop(channel_idx, None)
         self._active_channel_idx = channel_idx
         idxs = [ch["idx"] for ch in self._channels]
         if channel_idx in idxs:
             list_view = self.query_one("#channel_list", ListView)
             list_view.index = idxs.index(channel_idx)
+            if had_unread:
+                self._refresh_channel_item(channel_idx)
+        if had_unread:
+            getattr(self.app, "_update_tab_labels", lambda: None)()
         self._refresh_log()
 
     def action_prev_channel(self) -> None:
@@ -197,10 +242,14 @@ class ChatTab(TabPane):
         })
         if channel_idx == self._active_channel_idx:
             self._refresh_log()
+        else:
+            self._unread[channel_idx] = self._unread.get(channel_idx, 0) + 1
+            self._refresh_channel_item(channel_idx)
 
     def clear(self) -> None:
         """Clear all messages and channels (called on disconnect)."""
         self._messages.clear()
+        self._unread.clear()
         self._active_channel_idx = 0
         self._refresh_log()
         self.populate_channels([])

--- a/src/meshcore_tools/repeaters.py
+++ b/src/meshcore_tools/repeaters.py
@@ -182,6 +182,10 @@ class RepeatersTab(TabPane):
         text-style: bold;
         border-top: solid $panel-lighten-1;
     }
+    RepeatersTab #repeater_list ListItem.has-unread Label {
+        text-style: bold;
+        color: $warning;
+    }
     RepeatersTab #right_pane {
         width: 1fr;
         height: 1fr;
@@ -219,6 +223,7 @@ class RepeatersTab(TabPane):
         self._active_cmd_idx: int = 0
         self._tab_active: bool = False
         self._login_state: dict[int, bool] = {}  # contact index → logged in
+        self._unread: dict[int, int] = {}  # contact index → unread count
 
     def compose(self) -> ComposeResult:
         yield ListView(id="repeater_list")
@@ -325,6 +330,35 @@ class RepeatersTab(TabPane):
         except Exception:
             pass
 
+    def _find_list_pos(self, contact_idx: int) -> int | None:
+        """Find the list view position for a given contact index (skipping header rows)."""
+        for pos, idx in enumerate(self._list_item_map):
+            if idx == contact_idx:
+                return pos
+        return None
+
+    def _refresh_contact_item(self, contact_idx: int) -> None:
+        """Update a single contact list item's label and CSS class."""
+        pos = self._find_list_pos(contact_idx)
+        if pos is None or contact_idx >= len(self._repeaters):
+            return
+        contact = self._repeaters[contact_idx]
+        name = contact.get("adv_name") or contact.get("name") or contact.get("public_key", "?")[:8]
+        count = self._unread.get(contact_idx, 0)
+        label_text = f"  {name}" + (f"  [{count}]" if count else "")
+        list_view = self.query_one("#repeater_list", ListView)
+        items = list(list_view.query(ListItem))
+        if pos < len(items):
+            items[pos].query_one(Label).update(label_text)
+            if count > 0:
+                items[pos].add_class("has-unread")
+            else:
+                items[pos].remove_class("has-unread")
+
+    def unread_count(self) -> int:
+        """Total unread messages across all contacts."""
+        return sum(self._unread.values())
+
     # Display order for contact type groups
     _TYPE_ORDER = [1, 2, 3, 4, 0]
     _TYPE_LABEL = {0: "Unknown", 1: "CLI", 2: "Repeaters", 3: "Room Servers", 4: "Sensors"}
@@ -334,6 +368,7 @@ class RepeatersTab(TabPane):
         self._repeaters = contacts
         self._list_item_map = []
         self._selected_idx = None
+        self._unread.clear()
         list_view = self.query_one("#repeater_list", ListView)
         list_view.clear()
 
@@ -375,6 +410,11 @@ class RepeatersTab(TabPane):
         contact_idx = self._list_item_map[pos]
         if contact_idx is None:
             return  # header row — keep current selection
+        had_unread = contact_idx in self._unread
+        self._unread.pop(contact_idx, None)
+        if had_unread:
+            self._refresh_contact_item(contact_idx)
+            getattr(self.app, "_update_tab_labels", lambda: None)()
         self._selected_idx = contact_idx
         self._active_cmd_idx = 0
         self._update_cmd_visibility()
@@ -491,6 +531,9 @@ class RepeatersTab(TabPane):
             None,
         )
         self._log(f"[bold]{markup_escape(sender)}:[/bold] {markup_escape(text)}", "green", idx=contact_idx)
+        if contact_idx is not None and contact_idx != self._selected_idx:
+            self._unread[contact_idx] = self._unread.get(contact_idx, 0) + 1
+            self._refresh_contact_item(contact_idx)
 
     def receive_login_changed(self, pubkey_prefix: str, success: bool) -> None:
         """Update per-contact login state and refresh the Login button."""
@@ -640,6 +683,7 @@ class RepeatersTab(TabPane):
         self._selected_idx = None
         self._contact_logs = {}
         self._login_state = {}
+        self._unread.clear()
         self.query_one("#repeater_list", ListView).clear()
         self.query_one("#output_content", Static).update("")
         self._update_cmd_visibility()


### PR DESCRIPTION
Implements per-channel and per-contact unread message indicators as described in #6.

- Channel list rows show `[N]` badge and bold/warning colour when unread
- F2 Channels tab label shows ● when any channel has unread messages
- Contact list rows show `[N]` badge and bold/warning colour when unread
- F3 Contacts tab label shows ● when any contact has unread messages
- Counters clear when user selects the channel/contact

Closes #6

Generated with [Claude Code](https://claude.ai/code)