### PR TITLE
feat: import channels from channels.txt to connected companion

### DIFF
--- a/src/meshcore_tools/chat.py
+++ b/src/meshcore_tools/chat.py
@@ -9,13 +9,80 @@ from rich.markup import escape as markup_escape
 from textual import work
 from textual.app import ComposeResult
 from textual.binding import Binding
-from textual.containers import Container, VerticalScroll
-from textual.widgets import Input, Label, ListItem, ListView, Static, TabPane
+from textual.containers import Container, Horizontal, VerticalScroll
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Label, ListItem, ListView, SelectionList, Static, TabPane
 
 if TYPE_CHECKING:
     from meshcore_tools.companion import CompanionManager
 
 _MAX_MSG_LEN = 133
+_MAX_COMPANION_CHANNELS = 8
+
+
+class _ImportChannelsScreen(ModalScreen[list[tuple[str, bytes]] | None]):
+    """Modal: choose which channels from channels.txt to push to the companion."""
+
+    BINDINGS = [Binding("escape", "cancel", "Cancel")]
+
+    DEFAULT_CSS = """
+    _ImportChannelsScreen {
+        align: center middle;
+    }
+    _ImportChannelsScreen > Container {
+        width: 60;
+        height: auto;
+        max-height: 80%;
+        border: solid $accent;
+        background: $surface;
+        padding: 1 2;
+    }
+    _ImportChannelsScreen SelectionList {
+        height: auto;
+        max-height: 20;
+        border: solid $panel;
+        margin-bottom: 1;
+    }
+    _ImportChannelsScreen Horizontal {
+        height: 3;
+    }
+    _ImportChannelsScreen Button {
+        margin-right: 1;
+    }
+    """
+
+    def __init__(self, channels: list[tuple[str, bytes]]) -> None:
+        super().__init__()
+        self._channels = channels
+
+    def compose(self) -> ComposeResult:
+        with Container():
+            yield Static("[bold]Import channels to companion[/bold]", markup=True)
+            yield Static(
+                "Select channels to write to the companion device:",
+                markup=True,
+            )
+            yield SelectionList(
+                *[(name, i, True) for i, (name, _) in enumerate(self._channels)],
+                id="channel_selection",
+            )
+            with Horizontal():
+                yield Button("Import", variant="primary", id="btn_ok")
+                yield Button("Cancel", id="btn_cancel")
+
+    def on_mount(self) -> None:
+        self.query_one("#channel_selection", SelectionList).focus()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn_cancel":
+            self.dismiss(None)
+        elif event.button.id == "btn_ok":
+            sel = self.query_one("#channel_selection", SelectionList)
+            selected_indices = list(sel.selected)
+            self.dismiss([self._channels[i] for i in selected_indices])
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
 
 
 class ChatTab(TabPane):
@@ -32,10 +99,19 @@ class ChatTab(TabPane):
         height: 1fr;
         layout: horizontal;
     }
-    ChatTab #channel_list {
+    ChatTab #left_pane {
         width: 20;
         height: 1fr;
+        layout: vertical;
         border-right: solid $accent;
+    }
+    ChatTab #channel_list {
+        width: 1fr;
+        height: 1fr;
+    }
+    ChatTab #btn_import_channels {
+        width: 1fr;
+        height: 3;
     }
     ChatTab #right_pane {
         width: 1fr;
@@ -75,7 +151,9 @@ class ChatTab(TabPane):
         self._unread: dict[int, int] = {}  # channel_idx → unread count
 
     def compose(self) -> ComposeResult:
-        yield ListView(id="channel_list")
+        with Container(id="left_pane"):
+            yield ListView(id="channel_list")
+            yield Button("Import channels", id="btn_import_channels")
         with Container(id="right_pane"):
             with VerticalScroll(id="msg_log"):
                 yield Static("", id="msg_content", markup=True)
@@ -224,6 +302,94 @@ class ChatTab(TabPane):
         idxs = [ch["idx"] for ch in self._channels]
         pos = idxs.index(self._active_channel_idx) if self._active_channel_idx in idxs else 0
         self._select_channel(idxs[(pos + 1) % len(idxs)])
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn_import_channels":
+            self._action_import_channels()
+
+    def _action_import_channels(self) -> None:
+        """Compute the diff vs channels.txt and open the import modal."""
+        companion: CompanionManager | None = getattr(self.app, "companion", None)
+        if companion is None or not companion.is_connected:
+            self.app.notify("Companion not connected", severity="warning")
+            return
+
+        channels_path: str | None = getattr(self.app, "_channels_path", None)
+        if not channels_path:
+            self.app.notify(
+                "No channels file configured (use --channels option)", severity="warning"
+            )
+            return
+
+        from meshcore_tools.channels import load_channels
+
+        txt_channels = load_channels(channels_path)
+        if not txt_channels:
+            self.app.notify("No channels found in channels.txt", severity="warning")
+            return
+
+        companion_names = {ch["name"].lower() for ch in self._channels}
+        new_channels = [
+            (name, key) for name, key in txt_channels if name.lower() not in companion_names
+        ]
+
+        if not new_channels:
+            self.app.notify("All channels from channels.txt are already on the companion")
+            return
+
+        available_slots = _MAX_COMPANION_CHANNELS - len(self._channels)
+        if available_slots <= 0:
+            self.app.notify(
+                "All 8 companion channel slots are occupied", severity="warning"
+            )
+            return
+
+        if len(new_channels) > available_slots:
+            self.app.notify(
+                f"Only {available_slots} slot(s) available; "
+                f"showing first {available_slots} channel(s)",
+                severity="warning",
+            )
+            new_channels = new_channels[:available_slots]
+
+        self.app.push_screen(
+            _ImportChannelsScreen(new_channels),
+            self._on_import_confirmed,
+        )
+
+    def _on_import_confirmed(
+        self, selected: list[tuple[str, bytes]] | None
+    ) -> None:
+        if not selected:
+            return
+        self._do_import(selected)
+
+    @work(thread=False, exclusive=False)
+    async def _do_import(self, channels_to_import: list[tuple[str, bytes]]) -> None:
+        manager: CompanionManager | None = getattr(self.app, "companion", None)
+        if manager is None:
+            self.app.notify("Companion not connected", severity="error")
+            return
+
+        next_slot = max((ch["idx"] for ch in self._channels), default=-1) + 1
+        errors: list[str] = []
+        imported = 0
+
+        for name, secret in channels_to_import:
+            result = await manager.set_channel(next_slot, name, secret)
+            if result == "ok":
+                imported += 1
+                next_slot += 1
+            else:
+                errors.append(f"{name}: {result}")
+
+        if errors:
+            self.app.notify(
+                f"Import errors: {'; '.join(errors)}", severity="error", timeout=8
+            )
+        if imported:
+            self.app.notify(f"Imported {imported} channel(s)")
+            await manager.fetch_channels()
 
     def receive_channel_message(
         self,

--- a/src/meshcore_tools/companion.py
+++ b/src/meshcore_tools/companion.py
@@ -560,3 +560,25 @@ class CompanionManager:
             return str(result)
         except Exception as exc:
             return f"error: {exc}"
+
+    async def set_channel(
+        self, channel_idx: int, channel_name: str, channel_secret: bytes
+    ) -> str:
+        """Write a channel slot on the companion. Returns 'ok' on success."""
+        if not self._client or not self._connected:
+            return "not connected"
+        try:
+            result = await self._client.commands.set_channel(
+                channel_idx, channel_name, channel_secret
+            )
+            if str(getattr(result, "type", "")) == str(_EventType.ERROR):
+                return f"error: {result.payload}"
+            return "ok"
+        except Exception as exc:
+            return f"error: {exc}"
+
+    async def fetch_channels(self) -> None:
+        """Re-fetch channels from the companion and post ChannelsUpdated."""
+        if not self._client or not self._connected:
+            return
+        await self._fetch_channels()


### PR DESCRIPTION
Implements #issue-5: adds an "Import channels" button in the Chat tab that reads channels.txt, computes the diff against the companion's current channels, shows a selection modal, and writes the chosen channels to the device.

Closes #5

Generated with [Claude Code](https://claude.ai/code)