### PR TITLE
feat: add settings.toml to persist default region

### DIFF
--- a/src/meshcore_tools/cli.py
+++ b/src/meshcore_tools/cli.py
@@ -6,6 +6,16 @@ import os
 from meshcore_tools.providers.letsmesh_rest import DEFAULT_REGION
 
 
+def _resolve_region(explicit: str | None) -> str:
+    """Return the region to use, saving it to config when explicitly provided."""
+    from meshcore_tools.config import get_region, save_region
+    if explicit is not None:
+        save_region(explicit)
+        return explicit
+    saved = get_region()
+    return saved if saved is not None else DEFAULT_REGION
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="meshcore-tools",
@@ -20,7 +30,7 @@ def main() -> None:
     nodes_sub.required = True
 
     update_p = nodes_sub.add_parser("update", help="update database from input files and API")
-    update_p.add_argument("--region", default=DEFAULT_REGION, metavar="REGION")
+    update_p.add_argument("--region", default=None, metavar="REGION")
 
     lookup_p = nodes_sub.add_parser("lookup", help="find node(s) by public key prefix")
     lookup_p.add_argument("prefix", metavar="HEX_PREFIX")
@@ -30,7 +40,7 @@ def main() -> None:
 
     # --- monitor subcommand (alias for default TUI) ---
     monitor_p = sub.add_parser("monitor", help="live packet monitoring TUI (default)")
-    monitor_p.add_argument("--region", default=DEFAULT_REGION, metavar="REGION")
+    monitor_p.add_argument("--region", default=None, metavar="REGION")
     monitor_p.add_argument("--poll", type=int, default=5, metavar="SECONDS",
                            help="polling interval in seconds (default: 5)")
     monitor_p.add_argument("--channels", metavar="FILE", default=None,
@@ -45,7 +55,7 @@ def main() -> None:
             from meshcore_tools.db import update
             from meshcore_tools.providers.letsmesh_rest import LetsmeshRestProvider
             from meshcore_tools.providers.meshcore_rest import MeshcoreRestProvider
-            update(args.region, node_provider=LetsmeshRestProvider(), coord_provider=MeshcoreRestProvider())
+            update(_resolve_region(args.region), node_provider=LetsmeshRestProvider(), coord_provider=MeshcoreRestProvider())
         elif args.nodes_command == "lookup":
             from meshcore_tools.nodes import lookup
             lookup(args.prefix)
@@ -55,7 +65,7 @@ def main() -> None:
 
     else:
         # Default (no subcommand) and "monitor" both launch MeshCoreApp
-        region = getattr(args, "region", DEFAULT_REGION)
+        region = _resolve_region(getattr(args, "region", None))
         poll = getattr(args, "poll", 5)
         channels = getattr(args, "channels", None)
         if channels is None and os.path.exists("channels.txt"):

--- a/src/meshcore_tools/config.py
+++ b/src/meshcore_tools/config.py
@@ -1,0 +1,80 @@
+"""User settings persistence — XDG-compliant TOML config file."""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from pathlib import Path
+
+
+def _default_config_dir() -> Path:
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".config"
+    return base / "meshcore-tools"
+
+
+def load_settings(config_dir: Path | None = None) -> dict:
+    """Load settings from settings.toml; return empty dict if missing or corrupt."""
+    if config_dir is None:
+        config_dir = _default_config_dir()
+    path = config_dir / "settings.toml"
+    if not path.exists():
+        return {}
+    try:
+        return tomllib.loads(path.read_text())
+    except tomllib.TOMLDecodeError:
+        return {}
+
+
+def save_settings(data: dict, config_dir: Path | None = None) -> None:
+    """Write *data* to settings.toml, creating the directory if needed."""
+    if config_dir is None:
+        config_dir = _default_config_dir()
+    config_dir.mkdir(parents=True, exist_ok=True)
+    path = config_dir / "settings.toml"
+    path.write_text(_to_toml(data))
+
+
+def get_region(config_dir: Path | None = None) -> str | None:
+    """Return the saved default region, or None if not set."""
+    settings = load_settings(config_dir)
+    return settings.get("general", {}).get("region")
+
+
+def save_region(region: str, config_dir: Path | None = None) -> None:
+    """Persist *region* as the default region in settings.toml."""
+    settings = load_settings(config_dir)
+    settings.setdefault("general", {})["region"] = region
+    save_settings(settings, config_dir)
+
+
+# ---------------------------------------------------------------------------
+# Minimal TOML writer (no third-party dependency needed for writing)
+# ---------------------------------------------------------------------------
+
+def _to_toml(data: dict) -> str:
+    """Serialize a shallow dict-of-dicts to TOML text."""
+    lines: list[str] = []
+    scalars = {k: v for k, v in data.items() if not isinstance(v, dict)}
+    tables = {k: v for k, v in data.items() if isinstance(v, dict)}
+    for k, v in scalars.items():
+        lines.append(f"{k} = {_toml_value(v)}")
+    for section, inner in tables.items():
+        if lines:
+            lines.append("")
+        lines.append(f"[{section}]")
+        for k, v in inner.items():
+            lines.append(f"{k} = {_toml_value(v)}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _toml_value(v: object) -> str:
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    if isinstance(v, (int, float)):
+        return str(v)
+    if isinstance(v, str):
+        escaped = v.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    raise TypeError(f"Unsupported TOML value type: {type(v)}")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,77 @@
+"""Tests for config.py — XDG-compliant settings persistence."""
+
+from pathlib import Path
+
+import pytest
+
+from meshcore_tools.config import (
+    get_region,
+    load_settings,
+    save_region,
+    save_settings,
+)
+
+
+def test_load_settings_missing_file(tmp_path):
+    assert load_settings(tmp_path) == {}
+
+
+def test_load_settings_corrupt_toml(tmp_path):
+    (tmp_path / "settings.toml").write_text("not valid toml ][")
+    assert load_settings(tmp_path) == {}
+
+
+def test_save_and_load_settings(tmp_path):
+    save_settings({"general": {"region": "EU"}}, tmp_path)
+    result = load_settings(tmp_path)
+    assert result == {"general": {"region": "EU"}}
+
+
+def test_save_settings_creates_directory(tmp_path):
+    deep = tmp_path / "a" / "b" / "meshcore-tools"
+    save_settings({"general": {"region": "US"}}, deep)
+    assert (deep / "settings.toml").exists()
+
+
+def test_save_settings_preserves_other_keys(tmp_path):
+    save_settings({"general": {"region": "LUX", "other": "value"}}, tmp_path)
+    result = load_settings(tmp_path)
+    assert result["general"]["other"] == "value"
+    assert result["general"]["region"] == "LUX"
+
+
+def test_get_region_returns_none_when_missing(tmp_path):
+    assert get_region(tmp_path) is None
+
+
+def test_get_region_returns_saved_value(tmp_path):
+    save_settings({"general": {"region": "AP"}}, tmp_path)
+    assert get_region(tmp_path) == "AP"
+
+
+def test_save_region_creates_file(tmp_path):
+    save_region("NA", tmp_path)
+    assert (tmp_path / "settings.toml").exists()
+    assert get_region(tmp_path) == "NA"
+
+
+def test_save_region_overwrites_previous(tmp_path):
+    save_region("LUX", tmp_path)
+    save_region("EU", tmp_path)
+    assert get_region(tmp_path) == "EU"
+
+
+def test_save_region_preserves_other_settings(tmp_path):
+    save_settings({"general": {"region": "LUX", "foo": "bar"}}, tmp_path)
+    save_region("EU", tmp_path)
+    result = load_settings(tmp_path)
+    assert result["general"]["foo"] == "bar"
+    assert result["general"]["region"] == "EU"
+
+
+def test_xdg_config_home_respected(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    save_region("XDG", config_dir=None)  # uses env var path
+    expected_dir = tmp_path / "meshcore-tools"
+    assert (expected_dir / "settings.toml").exists()
+    assert get_region(config_dir=None) == "XDG"


### PR DESCRIPTION
Implements #7 — XDG-compliant settings file to persist the default region.

- New `src/meshcore_tools/config.py` using `tomllib` (stdlib) with minimal TOML writer
- XDG_CONFIG_HOME honoured, fallback to ~/.config/meshcore-tools/
- `cli.py`: saves region when explicitly passed, reads from config otherwise
- 11 new tests in `tests/test_config.py`

Closes #7

Generated with [Claude Code](https://claude.ai/code)